### PR TITLE
Add schedule and unschedule helper functions (emq 0.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 EventMQ
 =======
-[![Circle CI](https://circleci.com/gh/enderlabs/eventmq.svg?style=svg&circle-token=312da6ae260c2302baed268d2e052ce5e81cc71f)](https://circleci.com/gh/enderlabs/eventmq)
-[![Coverage Status](https://coveralls.io/repos/github/enderlabs/eventmq/badge.svg?branch=master)](https://coveralls.io/github/enderlabs/eventmq?branch=master)
+[![CircleCI](https://circleci.com/gh/eventmq/eventmq.svg?style=svg)](https://circleci.com/gh/eventmq/eventmq)
+[![Coverage Status](https://coveralls.io/repos/github/eventmq/eventmq/badge.svg)](https://coveralls.io/github/eventmq/eventmq)
 
 # Overview
 EventMQ is a message passing system built on [ZeroMQ](https://zeromq.org)
@@ -17,14 +17,18 @@ pip install eventmq
 # Support
 ## Documenation
 
-[Documentation](https://enderlabs.github.io/eventmq/)
+[Documentation](https://eventmq.github.io/eventmq/)
 
 ## Mailing Lists
 User Support: http://lists.eventmq.io/listinfo.cgi/eventmq-users-eventmq.io
 
 Development Discussion: http://lists.eventmq.io/listinfo.cgi/eventmq-devel-eventmq.io
 
-## Quick Start
+## IRC
+
+ #eventmq on [irc.freenode.net](https://webchat.freenode.net/?channels=#eventmq)
+
+# Quick Start
 
 my_jerbs.py
 ``` python

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3'
+__version__ = '0.3.1'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -4,4 +4,4 @@ __version__ = '0.3'
 PROTOCOL_VERSION = 'eMQP/1.0'
 
 from .client.messages import defer_job  # noqa
-from .client.jobs import job  # noqa
+from .client.jobs import job, schedule, unschedule  # noqa

--- a/eventmq/client/jobs.py
+++ b/eventmq/client/jobs.py
@@ -20,7 +20,9 @@ import logging
 import os
 
 from . import messages
+from .. import conf
 from ..constants import ENV_BROKER_ADDR
+from ..exceptions import ConnectionError
 from ..sender import Sender
 
 logger = logging.getLogger(__name__)
@@ -29,6 +31,10 @@ logger = logging.getLogger(__name__)
 class Job(object):
     """
     Defines a deferred EventMQ job.
+
+    .. note::
+
+       All passed class & function kwargs/args MUST be json serializable.
 
     Usage:
 
@@ -68,6 +74,8 @@ class Job(object):
                 can set this to False. This is useful for unit tests.
 
         """
+        # conf.BROKER_ADDR isn't used because /etc/eventmq.conf is for the
+        # daemons.
         self.broker_addr = broker_addr or os.environ.get(ENV_BROKER_ADDR)
         self.queue = queue
         self.async = async
@@ -104,3 +112,103 @@ def job(func, broker_addr=None, queue=None, async=True, *args, **kwargs):
         return decorator(func)
     else:
         return decorator
+
+
+def schedule(func, broker_addr=None, interval_secs=None, args=(), kwargs=None,
+             class_args=(), class_kwargs=None, headers=('guarantee',),
+             queue=conf.DEFAULT_QUEUE_NAME, cron=None):
+    """
+    Execute a task on a defined interval.
+
+    .. note::
+
+       All passed class & function kwargs/args MUST be json serializable.
+
+    Args:
+        func (callable): the callable (or string path to calable) to be
+            scheduled on a worker
+        broker_addr (str): Address of the broker to send the job to. If no
+            address is given then the value of the environment variable
+            ``EMQ_BROKER_ADDR`` will be used.
+        interval_secs (int): Run job every interval_secs or None if using cron
+        args (list): list of *args to pass to the callable
+        kwargs (dict): dict of **kwargs to pass to the callable
+        class_args (list): list of *args to pass to the class (if applicable)
+        class_kwargs (dict): dict of **kwargs to pass to the class (if
+            applicable)
+        headers (list): list of strings denoting enabled headers. Default:
+            guarantee is enabled to ensure the scheduler schedules the job.
+        queue (str): name of the queue to use when executing the job. The
+            default value is the default queue.
+        cron (string): cron formatted string used for job schedule if
+            interval_secs is None, i.e. '* * * * *' (every minute)
+    Raises:
+        TypeError: When one or more parameters are not JSON serializable.
+    Returns:
+       str: ID of the schedule message that was sent. None if there was an
+           error
+    """
+    socket = Sender()
+    # conf.BROKER_ADDR isn't used because /etc/eventmq.conf is for the daemons.
+    broker_addr = broker_addr or os.environ.get(ENV_BROKER_ADDR)
+
+    if not broker_addr:
+        raise ConnectionError('unknown broker address: {}'.format(broker_addr))
+
+    socket.connect(addr=broker_addr)
+
+    return messages.schedule(
+        socket, func, interval_secs=interval_secs, args=args,
+        kwargs=kwargs, class_args=class_args, class_kwargs=class_kwargs,
+        headers=headers, queue=conf.DEFAULT_QUEUE_NAME, cron=cron)
+
+
+def unschedule(func, broker_addr=None, interval_secs=None, args=(),
+               kwargs=None, class_args=(), class_kwargs=None,
+               headers=('guarantee',), queue=conf.DEFAULT_QUEUE_NAME,
+               cron=None):
+    """
+    Stop periodically executing a task
+
+    .. note::
+
+       All passed class & function kwargs/args MUST be json serializable.
+
+    Args:
+        func (callable): the callable (or string path to calable) to be
+            scheduled on a worker
+        broker_addr (str): Address of the broker to send the job to. If no
+            address is given then the value of the environment variable
+            ``EMQ_BROKER_ADDR`` will be used.
+        interval_secs (int): Run job every interval_secs or None if using cron
+        args (list): list of *args to pass to the callable
+        kwargs (dict): dict of **kwargs to pass to the callable
+        class_args (list): list of *args to pass to the class (if applicable)
+        class_kwargs (dict): dict of **kwargs to pass to the class (if
+            applicable)
+        headers (list): list of strings denoting enabled headers. Default:
+            guarantee is enabled to ensure the scheduler schedules the job.
+        queue (str): name of the queue to use when executing the job. The
+            default value is the default queue.
+        cron (string): cron formatted string used for job schedule if
+            interval_secs is None, i.e. '* * * * *' (every minute)
+    Raises:
+        TypeError: When one or more parameters are not JSON serializable.
+    Returns:
+       str: ID of the schedule message that was sent. None if there was an
+           error
+    """
+    socket = Sender()
+    # conf.BROKER_ADDR isn't used because /etc/eventmq.conf is for the daemons.
+    broker_addr = broker_addr or os.environ.get(ENV_BROKER_ADDR)
+
+    if not broker_addr:
+        raise ConnectionError('unknown broker address: {}'.format(broker_addr))
+
+    socket.connect(addr=broker_addr)
+
+    return messages.schedule(
+        socket, func, interval_secs=interval_secs, args=args,
+        kwargs=kwargs, class_args=class_args, class_kwargs=class_kwargs,
+        headers=headers, queue=conf.DEFAULT_QUEUE_NAME, cron=cron,
+        unschedule=True)

--- a/eventmq/client/jobs.py
+++ b/eventmq/client/jobs.py
@@ -152,10 +152,10 @@ def schedule(func, broker_addr=None, interval_secs=None, args=(), kwargs=None,
     # conf.BROKER_ADDR isn't used because /etc/eventmq.conf is for the daemons.
     broker_addr = broker_addr or os.environ.get(ENV_BROKER_ADDR)
 
+    socket.connect(broker_addr)
+
     if not broker_addr:
         raise ConnectionError('unknown broker address: {}'.format(broker_addr))
-
-    socket.connect(addr=broker_addr)
 
     return messages.schedule(
         socket, func, interval_secs=interval_secs, args=args,
@@ -201,6 +201,7 @@ def unschedule(func, broker_addr=None, interval_secs=None, args=(),
     socket = Sender()
     # conf.BROKER_ADDR isn't used because /etc/eventmq.conf is for the daemons.
     broker_addr = broker_addr or os.environ.get(ENV_BROKER_ADDR)
+    socket.connect(broker_addr)
 
     if not broker_addr:
         raise ConnectionError('unknown broker address: {}'.format(broker_addr))

--- a/eventmq/client/messages.py
+++ b/eventmq/client/messages.py
@@ -42,9 +42,8 @@ def schedule(socket, func, interval_secs=None, args=(), kwargs=None,
         socket (socket): eventmq socket to use for sending the message
         func (callable): the callable (or string path to calable) to be
             scheduled on a worker
-        minutes (int): minutes to wait in between executions
-        args (list): list of *args to pass to the callable
         interval_secs (int): Run job every interval_secs or None if using cron
+        args (list): list of *args to pass to the callable
         cron (string): cron formatted string used for job schedule if
             interval_secs is None, i.e. '* * * * *' (every minute)
         kwargs (dict): dict of **kwargs to pass to the callable

--- a/eventmq/client/messages.py
+++ b/eventmq/client/messages.py
@@ -65,11 +65,6 @@ def schedule(socket, func, interval_secs=None, args=(), kwargs=None,
     if not kwargs:
         kwargs = {}
 
-    if not len(class_args) > 0 and not cron:
-        logger.error('First `class_args` argument must be caller_id for '
-                     'scheduling interval jobs')
-        return
-
     if not unschedule and \
        ((interval_secs and cron) or (not interval_secs and not cron)):
         logger.error('You must sepcify either `interval_secs` or `cron`, '

--- a/eventmq/exceptions.py
+++ b/eventmq/exceptions.py
@@ -62,3 +62,9 @@ class CallableFromPathError(EventMQError):
     Raised when construction of a callable from a path and callable_name fails.
     """
     pass
+
+
+class ConnectionError(EventMQError):
+    """
+    Raised when there is an error connecting to a network service.
+    """

--- a/eventmq/tests/test_client_jobs.py
+++ b/eventmq/tests/test_client_jobs.py
@@ -66,6 +66,27 @@ class TestCase(unittest.TestCase):
         f = decorate(test_func)
         self.assertEqual(f(), 12)
 
+    @mock.patch('eventmq.client.jobs.Sender')
+    @mock.patch('eventmq.client.messages.schedule')
+    def test_schedule_helper(self, sched_mock, Sender_mock):
+        jobs.schedule(test_func, broker_addr=self.BROKER_ADDR,
+                      interval_secs=20)
+
+        sched_mock.assert_called_with(
+            Sender_mock(), test_func, args=(), class_args=(),
+            class_kwargs=None, cron=None, headers=('guarantee',),
+            interval_secs=20, kwargs=None, queue='default')
+
+    @mock.patch('eventmq.client.jobs.Sender')
+    @mock.patch('eventmq.client.messages.schedule')
+    def test_unschedule_helper(self, sched_mock, Sender_mock):
+        jobs.unschedule(test_func, broker_addr=self.BROKER_ADDR)
+
+        sched_mock.assert_called_with(
+            Sender_mock(), test_func, args=(), class_args=(),
+            class_kwargs=None, cron=None, headers=('guarantee',),
+            interval_secs=None, kwargs=None, queue='default', unschedule=True)
+
 
 def test_func():
     return 12

--- a/eventmq/tests/test_client_messages.py
+++ b/eventmq/tests/test_client_messages.py
@@ -208,10 +208,6 @@ class TestCase(unittest.TestCase):
                               class_args=(123,),
                               interval_secs=23)
 
-            # error if class_args does't have an inital id. (if this test needs
-            # to be removed, also remove the class_args from the above calls)
-            messages.schedule(socket, json.dumps)
-
             # error if neither cron or interval_secs is specified
             messages.schedule(socket, json.dumps, class_args=(123,))
 
@@ -237,9 +233,6 @@ class TestCase(unittest.TestCase):
                 ('eventmq.client.messages',
                  'ERROR',
                  'Encountered invalid callable, will not proceed.'),
-                ('eventmq.client.messages',
-                 'ERROR',
-                 'First `class_args` argument must be caller_id for scheduling interval jobs'),  # noqa
                 ('eventmq.client.messages',
                  'ERROR',
                  'You must sepcify either `interval_secs` or `cron`, but not both (or neither)'),  # noqa

--- a/eventmq/tests/test_scheduler.py
+++ b/eventmq/tests/test_scheduler.py
@@ -13,7 +13,6 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
-import json
 import unittest
 
 from .. import constants, scheduler
@@ -29,41 +28,6 @@ class TestCase(unittest.TestCase):
         self.assertFalse(sched.awaiting_startup_ack)
         self.assertEqual(sched.status, constants.STATUS.ready)
 
-    def test_schedule_hash(self):
-        msg1 = [
-            'default',
-            '',
-            '3',
-            json.dumps(['run', {
-                'path': 'test',
-                'args': [33, 'asdf'],
-                'kwargs': {'zeta': 'Z', 'alpha': 'α'},
-                'class_args': [0],
-                'class_kwargs': {
-                    'donkey': True, 'apple': False},
-                'callable': 'do_the_thing'}]),
-            None
-        ]
-        h1 = scheduler.Scheduler.schedule_hash(msg1)
-        self.assertEqual('-8073720944288460190', h1)
-
-        # Reordering the message argument shouldn't change the hash value
-        msg2 = [
-            'default',
-            '',
-            '3',
-            json.dumps(['run', {
-                'class_kwargs': {
-                    'apple': False, 'donkey': True},
-                'args': [33, 'asdf'],
-                'class_args': [0],
-                'kwargs': {'alpha': 'α', 'zeta': 'Z'},
-                'path': 'test',
-                'callable': 'do_the_thing'}]),
-            None
-        ]
-        h2 = scheduler.Scheduler.schedule_hash(msg2)
-        self.assertEqual('-8073720944288460190', h2)
 
 # EMQP Tests
     def test_reset(self):

--- a/eventmq/tests/test_scheduler.py
+++ b/eventmq/tests/test_scheduler.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This file is part of eventmq.
 #
 # eventmq is free software: you can redistribute it and/or modify it under the
@@ -12,6 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
+import json
 import unittest
 
 from .. import constants, scheduler
@@ -26,6 +28,42 @@ class TestCase(unittest.TestCase):
 
         self.assertFalse(sched.awaiting_startup_ack)
         self.assertEqual(sched.status, constants.STATUS.ready)
+
+    def test_schedule_hash(self):
+        msg1 = [
+            'default',
+            '',
+            '3',
+            json.dumps(['run', {
+                'path': 'test',
+                'args': [33, 'asdf'],
+                'kwargs': {'zeta': 'Z', 'alpha': 'α'},
+                'class_args': [0],
+                'class_kwargs': {
+                    'donkey': True, 'apple': False},
+                'callable': 'do_the_thing'}]),
+            None
+        ]
+        h1 = scheduler.Scheduler.schedule_hash(msg1)
+        self.assertEqual('-8073720944288460190', h1)
+
+        # Reordering the message argument shouldn't change the hash value
+        msg2 = [
+            'default',
+            '',
+            '3',
+            json.dumps(['run', {
+                'class_kwargs': {
+                    'apple': False, 'donkey': True},
+                'args': [33, 'asdf'],
+                'class_args': [0],
+                'kwargs': {'alpha': 'α', 'zeta': 'Z'},
+                'path': 'test',
+                'callable': 'do_the_thing'}]),
+            None
+        ]
+        h2 = scheduler.Scheduler.schedule_hash(msg2)
+        self.assertEqual('-8073720944288460190', h2)
 
 # EMQP Tests
     def test_reset(self):

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3',
-    description='EventMQ messaging system based on ZeroMQ',
+    version='0.3.1',
+    description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',
                       'six==1.10.0',
@@ -32,7 +32,7 @@ setup(
               'mock==1.3.0'],
           },
     author='EventMQ Contributors',
-    url='https://github.com/enderlabs/eventmq/',
+    url='https://github.com/eventmq/eventmq/',
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -53,6 +53,8 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     scripts=[
         'bin/emq-cli',


### PR DESCRIPTION
- Add schedule and unschedule helper functions
- Serializes full argument list for messages and hashes that to uniquely identify jobs
- Removes unused `raw_jobs` part of code in `load_jobs`
- Removes unused `cron_hash` method
- Adds `connect` statements to the schedule/unschedule helper functions
- Adds coveralls for coverage reporting to circle.yml