### PR TITLE
Use SHA-1 instead of python's built-in hash() function for schedule_hash

### DIFF
--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -17,6 +17,7 @@
 =============================
 Handles cron and other scheduled tasks
 """
+from hashlib import sha1 as emq_hash
 import json
 from json import dumps as serialize
 from json import loads as deserialize
@@ -400,10 +401,10 @@ class Scheduler(HeartbeatMixin, EMQPService):
         Returns:
             int: unique hash for the job
         """
+
         # Get the job portion of the message
         msg = deserialize(message[3])[1]
 
-        # Items to use for uniquely identifying this scheduled job
         # Use json to create the hash string, sorting the keys.
         schedule_hash_items = json.dumps(
             {'args': msg['args'],
@@ -413,10 +414,10 @@ class Scheduler(HeartbeatMixin, EMQPService):
              'path': msg['path'],
              'callable': msg['callable']},
             sort_keys=True)
-        logger.debug('Hash string: {}'.format(schedule_hash_items))
 
         # Hash the sorted, immutable set of items in our identifying dict
-        schedule_hash = str(hash(schedule_hash_items))
+        schedule_hash = emq_hash(
+            schedule_hash_items.encode('utf-8')).hexdigest()
 
         return schedule_hash
 

--- a/eventmq/tests/test_scheduler.py
+++ b/eventmq/tests/test_scheduler.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
+import json
 import unittest
 
 from .. import constants, scheduler
@@ -28,6 +29,41 @@ class TestCase(unittest.TestCase):
         self.assertFalse(sched.awaiting_startup_ack)
         self.assertEqual(sched.status, constants.STATUS.ready)
 
+    def test_schedule_hash(self):
+        msg1 = [
+            'default',
+            '',
+            '3',
+            json.dumps(['run', {
+                'path': 'test',
+                'args': [33, 'asdf'],
+                'kwargs': {'zeta': 'Z', 'alpha': 'α'},
+                'class_args': [0],
+                'class_kwargs': {
+                    'donkey': True, 'apple': False},
+                'callable': 'do_the_thing'}]),
+            None
+        ]
+        h1 = scheduler.Scheduler.schedule_hash(msg1)
+        self.assertEqual('4658982cab9d32bf1ef9113a9d8bdec01775e2bc', h1)
+
+        # Reordering the message argument shouldn't change the hash value
+        msg2 = [
+            'default',
+            '',
+            '3',
+            json.dumps(['run', {
+                'class_kwargs': {
+                    'apple': False, 'donkey': True},
+                'args': [33, 'asdf'],
+                'class_args': [0],
+                'kwargs': {'alpha': 'α', 'zeta': 'Z'},
+                'path': 'test',
+                'callable': 'do_the_thing'}]),
+            None
+        ]
+        h2 = scheduler.Scheduler.schedule_hash(msg2)
+        self.assertEqual('4658982cab9d32bf1ef9113a9d8bdec01775e2bc', h2)
 
 # EMQP Tests
     def test_reset(self):


### PR DESCRIPTION
- Python's builtin hash() function uses a random seed to prevent 'tar-pitting'
  an application by setting keys designed to collide. See:
  http://www.ocert.org/advisories/ocert-2011-003.html