### PR TITLE
Implement pre/post hook support

### DIFF
--- a/bin/send_msg
+++ b/bin/send_msg
@@ -26,7 +26,7 @@ if __name__ == "__main__":
             'kwargs': {}
             }]
 
-        send_request(s, msg, guarantee=True, reply_requested=True, timeout=1)
+        send_request(s, msg, guarantee=True, reply_requested=True, timeout=10)
         print zmq.POLLOUT
         events = dict(poller.poll(500))
         print events

--- a/docs/settings_file.rst
+++ b/docs/settings_file.rst
@@ -4,12 +4,66 @@ Server Settings (eventmq.conf)
 EventMQ uses a standard INI style config file found at ``/etc/eventmq.conf``.
 
 ******
+Global
+******
+
+super_debug
+===========
+Default: False
+
+Enable most verbose level of debug statements
+
+******
 Router
 ******
+
+frontend_addr
+=============
+Default: 'tcp://127.0.0.1:47291'
+
+The address used to listen for client and scheduler connections
+
+
+backend_addr
+============
+Default: 'tcp://127.0.0.1:47291'
+
+The address used to listen for connections from workers
 
 *********
 Scheduler
 *********
+
+scheduler_addr
+==============
+Default: 'tcp://127.0.0.1:47291'
+
+The address the scheduler will use to connect to the broker
+
+rq_host
+=======
+Default: 'localhost'
+
+The hostname of the redis server used to persist scheduled jobs.  This is
+expected to support redis' save operation which saves the contents to disk.
+
+rq_port
+=======
+Default: 6379
+
+Port of redis server to connect to.
+
+rq_db
+=====
+Default: 0
+
+Which redis database to use
+
+rq_password
+===========
+Default: ''
+
+Password to use when connecting to redis
 
 ***********
 Job Manager
@@ -35,7 +89,7 @@ queues
 ======
 Default: [[10, "default"]]
 
-Comma seperated list of queues to process jobs for with thier weights. This list
+Comma seperated list of queues to process jobs for with their weights. This list
 must be valid JSON otherwise an error will be thrown.
 Example: ``queues=[[10, "data_process"], [15, "email"]]``.  With these
 weights and the ``CONCURRENT_JOBS`` setting, you should be able to tune managers
@@ -50,3 +104,17 @@ number until the large box is ready to accept another q1 job.
    It is recommended that you have some workers listening for jobs on your
    default queue so that anything that is not explicitly assigned will still be
    run.
+
+setup_callabe/setup_path
+========================
+Default: '' (Signifies no task will be attempted)
+
+Strings containing path and callable to be run when a worker is spawned
+if applicable to that type of worker.  Currently the only supported worker is a
+MultiProcessWorker, and is useful for pulling any global state into memory.
+
+max_job_count
+=============
+Default: 1024
+
+After a worker runs this amount of jobs, it will gracefully exit and be replaced

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/client/jobs.py
+++ b/eventmq/client/jobs.py
@@ -101,7 +101,8 @@ class Job(object):
         return f
 
 
-def job(func, broker_addr=None, queue=None, async=True, *args, **kwargs):
+def job(func, broker_addr=None, queue=None, async=True, *args,
+        **kwargs):
     """
     Functional decorator helper for creating a deferred eventmq job. See
     :class:`Job` for more information.

--- a/eventmq/client/messages.py
+++ b/eventmq/client/messages.py
@@ -108,7 +108,7 @@ def schedule(socket, func, interval_secs=None, args=(), kwargs=None,
 
 
 def defer_job(
-        socket, func, wrapper=None, args=(), kwargs=None, class_args=(),
+        socket, func, args=(), kwargs=None, class_args=(),
         class_kwargs=None, reply_requested=False, guarantee=False,
         retry_count=0, timeout=0, debounce_secs=False,
         queue=conf.DEFAULT_QUEUE_NAME):
@@ -126,8 +126,6 @@ def defer_job(
         socket (socket): eventmq socket to use for sending the message
         func (callable or str): the callable (or string path to callable) to be
             deferred to a worker
-        wrapper (callable): optional wrapper for the call to func to be
-             wrapped with
         args (list): list of *args for the callable
         kwargs (dict): dict of **kwargs for the callable
         class_args (list): list of *args to pass to the the class when
@@ -175,15 +173,6 @@ def defer_job(
         path, callable_name = split_callable_name(callable_name)
     else:
         logger.error('Encountered non-callable func: {}'.format(func))
-        return
-
-    if wrapper and callable(wrapper):
-        # Prepend the original path and callable name to args
-        args = (path, callable_name, args)
-        callable_name = name_from_callable(wrapper)
-        path, callable_name = split_callable_name(callable_name)
-    elif wrapper:
-        logger.error('Encountered non-callable wrapper: {}'.format(wrapper))
         return
 
     if not callable_name or not path:

--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -88,4 +88,8 @@ RQ_PASSWORD = ''
 
 MAX_JOB_COUNT = 1024
 
+# Path/Callable to run on start of a worker process
+SETUP_PATH = ''
+SETUP_CALLABLE = ''
+
 # }}}

--- a/eventmq/tests/test_jobmanager.py
+++ b/eventmq/tests/test_jobmanager.py
@@ -170,3 +170,8 @@ def start_jm(jm, addr):
 
 def pretend_job(t):
     time.sleep(t)
+
+
+def test_setup():
+    import time
+    assert time

--- a/eventmq/tests/test_worker.py
+++ b/eventmq/tests/test_worker.py
@@ -1,0 +1,65 @@
+# This file is part of eventmq.
+#
+# eventmq is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# eventmq is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
+
+from multiprocessing import Pool
+import time
+
+from nose import with_setup
+
+from .. import worker
+
+ADDR = 'inproc://pour_the_rice_in_the_thing'
+
+
+def setup_func():
+    global pool
+    global out
+    pool = Pool()
+    out = pool.map(job, range(1))
+
+
+@with_setup(setup_func)
+def test_run_with_timeout():
+    payload = {
+        'path': 'eventmq.tests.test_worker',
+        'callable': 'job',
+        'args': [2]
+    }
+
+    msgid = worker._run(payload)
+
+    assert msgid
+
+
+@with_setup(setup_func)
+def test_run_setup():
+    setup_callable = 'pre_hook'
+    setup_path = 'eventmq.tests.test_worker'
+
+    worker.run_setup(setup_path, setup_callable)
+
+
+def job(sleep_time=0):
+    time.sleep(sleep_time)
+
+    return True
+
+
+def pre_hook():
+    return 1
+
+
+def post_hook():
+    return 1

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -69,7 +69,9 @@ class MultiprocessWorker(Process):
                 try:
                     run_setup(conf.SETUP_PATH, conf.SETUP_CALLABLE)
                 except Exception as e:
-                    logger.warning('Unable to complete setup: ' + str(e))
+                    logger.warning('Unable to complete setup task ({}.{}): {}'
+                                   .format(conf.SETUP_PATH,
+                                           conf.SETUP_CALLABLE, str(e)))
 
         import zmq
         zmq.Context.instance().term()
@@ -167,7 +169,11 @@ def _run(payload):
 
 
 def run_setup(setup_path, setup_callable):
-    logger.debug("Running setup for worker id {}".format(os.getpid()))
+    logger.debug("Running setup ({}.{}) for worker id {}".format(
+        setup_path,
+        setup_callable,
+        os.getpid()))
+
     if ":" in setup_path:
         _pkgsplit = setup_path.split(':')
         s_setup_package = _pkgsplit[0]

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -65,7 +65,7 @@ class MultiprocessWorker(Process):
 
         if self.run_setup:
             self.run_setup = False
-            if conf.SETUP_CALLABLE and conf.SETUP_PATH:
+            if any(conf.SETUP_CALLABLE) and any(conf.SETUP_PATH):
                 try:
                     run_setup(conf.SETUP_PATH, conf.SETUP_CALLABLE)
                 except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.2',
+    version='0.3.3',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
(Edited)
What:
Issue #9 

Implement an optional setup callable (or path to callable as a str) that will run immediately when the worker is spawned, configurable through the eventmq.conf file

Tests:

Added Unit tests for run_setup