### PR TITLE
persist run count header

### DIFF
--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -144,6 +144,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
 
             cancel_jobs = []
             for k, v in self.interval_jobs.iteritems():
+                # TODO: Refactor this entire loop to be readable by humankind
                 # The schedule time has elapsed
                 if v[0] <= m_now:
                     msg = v[1]
@@ -160,6 +161,23 @@ class Scheduler(HeartbeatMixin, EMQPService):
                         else:
                             # Decrement run_count
                             v[4] -= 1
+                            # Persist the change to redis
+                            try:
+                                message = deserialize(self.redis_server.get(k))
+                                new_headers = []
+                                for header in message[1].split(','):
+                                    if 'run_count:' in header:
+                                        new_headers.append(
+                                            'run_count:{}'.format(v[4]))
+                                    else:
+                                        new_headers.append(header)
+                                message[1] = ",".join(new_headers)
+                                self.redis_server.set(k, serialize(message))
+                            except Exception as e:
+                                logger.warning(
+                                    'Unable to update key in redis '
+                                    'server: {}'.format(e))
+                            # Perform the request since run_count still > 0
                             self.send_request(msg, queue=queue)
                             v[0] = next(v[2])
                     else:


### PR DESCRIPTION
# What
Persist changes to run_count header to redis

Fixes Issue #19 

# Why
In case server crashes - this will maintain the scheduled number of times to run a job.  This allows a wrapper on jobs to act like a delay mechanism, i.e.

```
my_job.delay(15)
```

in order to delay execution of the job by 15 seconds.

# Tests
Locally the changes saved successfully through forced crashes of the scheduler.