### PR TITLE
Feature/better workers

### DIFF
--- a/bin/send_msg
+++ b/bin/send_msg
@@ -22,15 +22,15 @@ if __name__ == "__main__":
             'callable': 'pretend_job',
             'class_args': ('blurp',),
             'class_kwargs': {'kwarg1': True},
-            'args': (2, ),
+            'args': (1, ),
             'kwargs': {}
             }]
 
         send_request(s, msg, guarantee=True, reply_requested=True, timeout=10)
-        print zmq.POLLOUT
-        events = dict(poller.poll(500))
-        print events
-        if events[s.zsocket] == zmq.POLLIN:
-            msg = s.recv_multipart()
+        # print zmq.POLLOUT
+        # events = dict(poller.poll(500))
+        # print events
+        # if events[s.zsocket] == zmq.POLLIN:
+        #     msg = s.recv_multipart()
 
-            print msg
+        #     print msg

--- a/bin/send_msg
+++ b/bin/send_msg
@@ -22,15 +22,19 @@ if __name__ == "__main__":
             'callable': 'pretend_job',
             'class_args': ('blurp',),
             'class_kwargs': {'kwarg1': True},
-            'args': (2, ),
+            'args': (10, ),
             'kwargs': {}
             }]
 
-        send_request(s, msg, guarantee=True, reply_requested=True, timeout=1)
-        # print zmq.POLLOUT
-        # events = dict(poller.poll(500))
-        # print events
-        # if events[s.zsocket] == zmq.POLLIN:
-        #     msg = s.recv_multipart()
+        msgid = send_request(s, msg, guarantee=True, reply_requested=True, timeout=200)
+        print 'Sent message, use msgid={} to track responses'.format(msgid)
+        events = dict(poller.poll(500))
+        if events[s.zsocket] == zmq.POLLIN:
+            msg = s.recv_multipart()
+            print msg
 
-        #     print msg
+        # Wait for job reply
+        events = dict(poller.poll(50000))
+        if events[s.zsocket] == zmq.POLLIN:
+            msg = s.recv_multipart()
+            print msg

--- a/bin/send_msg
+++ b/bin/send_msg
@@ -22,11 +22,11 @@ if __name__ == "__main__":
             'callable': 'pretend_job',
             'class_args': ('blurp',),
             'class_kwargs': {'kwarg1': True},
-            'args': (1, ),
+            'args': (2, ),
             'kwargs': {}
             }]
 
-        send_request(s, msg, guarantee=True, reply_requested=True, timeout=10)
+        send_request(s, msg, guarantee=True, reply_requested=True, timeout=1)
         # print zmq.POLLOUT
         # events = dict(poller.poll(500))
         # print events

--- a/bin/send_msg
+++ b/bin/send_msg
@@ -19,22 +19,23 @@ if __name__ == "__main__":
 
         msg = ['run', {
             'path': 'eventmq.tests.test_jobmanager',
-            'callable': 'pretend_job',
+            'callable': 'work_job',
             'class_args': ('blurp',),
             'class_kwargs': {'kwarg1': True},
-            'args': (10, ),
+            'args': (50, ),
             'kwargs': {}
             }]
 
-        msgid = send_request(s, msg, guarantee=True, reply_requested=True, timeout=200)
-        print 'Sent message, use msgid={} to track responses'.format(msgid)
-        events = dict(poller.poll(500))
-        if events[s.zsocket] == zmq.POLLIN:
-            msg = s.recv_multipart()
-            print msg
+        msgid = send_request(s, msg, guarantee=True, reply_requested=True, timeout=10)
+        msgid = send_request(s, msg, guarantee=True, reply_requested=True)
+        # print 'Sent message, use msgid={} to track responses'.format(msgid)
+        # events = dict(poller.poll(500))
+        # if events[s.zsocket] == zmq.POLLIN:
+        #     msg = s.recv_multipart()
+        #     print msg
 
-        # Wait for job reply
-        events = dict(poller.poll(50000))
-        if events[s.zsocket] == zmq.POLLIN:
-            msg = s.recv_multipart()
-            print msg
+        # # Wait for job reply
+        # events = dict(poller.poll(50000))
+        # if events[s.zsocket] == zmq.POLLIN:
+        #     msg = s.recv_multipart()
+        #     print msg

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -92,4 +92,8 @@ MAX_JOB_COUNT = 1024
 SETUP_PATH = ''
 SETUP_CALLABLE = ''
 
+# Time to wait after receiving SIGTERM to kill the workers in the jobmanager
+# forecfully
+KILL_GRACE_PERIOD = 300
+
 # }}}

--- a/eventmq/tests/test_jobmanager.py
+++ b/eventmq/tests/test_jobmanager.py
@@ -174,6 +174,17 @@ def pretend_job(t):
     return "I slept for {} seconds".format(t)
 
 
+def work_job(t):
+    import time
+
+    begin_time = time.time()
+
+    while time.time() < begin_time + t:
+        a = 1+1
+
+    return a
+
+
 def test_setup():
     import time
     assert time

--- a/eventmq/tests/test_jobmanager.py
+++ b/eventmq/tests/test_jobmanager.py
@@ -67,6 +67,7 @@ class TestCase(unittest.TestCase):
             sender_mock.return_value)
 
         jm.received_disconnect = True
+        jm.should_reset = True
         jm._start_event_loop()
 
     def test_on_request(self):
@@ -170,6 +171,7 @@ def start_jm(jm, addr):
 
 def pretend_job(t):
     time.sleep(t)
+    return "I slept for {} seconds".format(t)
 
 
 def test_setup():

--- a/eventmq/tests/test_worker.py
+++ b/eventmq/tests/test_worker.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 from multiprocessing import Pool
 import time
 
@@ -38,7 +39,7 @@ def test_run_with_timeout():
         'args': [2]
     }
 
-    msgid = worker._run(payload)
+    msgid = worker._run(payload, logging.getLogger())
 
     assert msgid
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.3',
+    version='0.3.4',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
# What
Implements a better interface between jobmanager <-> worker.
Cleans up scenarios where processes die when they shouldn't.

# Tests
SIGKILL on the main emq-jobmanager process no longer leaves orphans/zombies
SIGTERM now is graceful as possible:
Manually spun up a worker/router for most of the testing here.  Cases I know I've hit:

Spin up workers and run no jobs on them -> SIGTERM (exits cleanly):
```2017-04-03 13:28:18,031 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:28:18,031 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:28:18,031 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:28:18,031 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:28:18,032 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:28:18,035 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 13:28:18,036 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 13:28:18,037 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 13:28:18,037 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 13:28:18,038 - eventmq.worker.31573  DEBUG - Worker death
2017-04-03 13:28:18,038 - eventmq.worker.31574  DEBUG - Worker death
2017-04-03 13:28:18,038 - eventmq.worker.31572  DEBUG - Worker death
2017-04-03 13:28:18,038 - eventmq.worker.31571  DEBUG - Worker death
2017-04-03 13:28:18,138 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 31574, 'callback': 'worker_death'}
2017-04-03 13:28:18,138 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 31573, 'callback': 'worker_death'}
2017-04-03 13:28:18,138 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 31572, 'callback': 'worker_death'}
2017-04-03 13:28:18,138 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 31571, 'callback': 'worker_death'}
```

Spun up workers and ran 4 jobs to sleep for 5 seconds with timeout=200, while they were running SIGTERM (exits cleanly after sending a REPLY for each job that eventually finishes)
```
^C2017-04-03 13:30:34,648 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:30:34,648 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:30:34,649 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:30:34,649 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:30:34,649 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 13:30:34,651 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 13:30:34,651 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 13:30:34,651 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 13:30:34,651 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 13:30:38,606 - eventmq.worker.32074  DEBUG - Worker death
2017-04-03 13:30:38,606 - eventmq.worker.32077  DEBUG - Worker death
2017-04-03 13:30:38,609 - eventmq.worker.32075  DEBUG - Worker death
2017-04-03 13:30:38,609 - eventmq.worker.32076  DEBUG - Worker death
2017-04-03 13:30:38,658 - eventmq.jobmanager  DEBUG - {'return': {'value': 'I slept for 5 seconds'}, 'msgid': '5679d15a-5298-476e-826e-c23ce90f9db1', 'pid': 32077, 'callback': 'worker_done_with_reply'}
2017-04-03 13:30:38,658 - eventmq.utils.classes  DEBUG - Sending message: ('', 'eMQP/1.0', 'REPLY', 'd68a93ca-c83e-45c4-b656-b497c0ec557a', '{"value": "I slept for 5 seconds"}', '5679d15a-5298-476e-826e-c23ce90f9db1')
2017-04-03 13:30:38,659 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 32077, 'callback': 'worker_death'}
2017-04-03 13:30:38,659 - eventmq.jobmanager  DEBUG - {'return': {'value': 'I slept for 5 seconds'}, 'msgid': 'dd7574f0-75eb-441e-8a79-0965366b0b4f', 'pid': 32074, 'callback': 'worker_done_with_reply'}
2017-04-03 13:30:38,659 - eventmq.utils.classes  DEBUG - Sending message: ('', 'eMQP/1.0', 'REPLY', '505d75f8-2d16-42a8-af78-b4c45796a339', '{"value": "I slept for 5 seconds"}', 'dd7574f0-75eb-441e-8a79-0965366b0b4f')
2017-04-03 13:30:38,660 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 32074, 'callback': 'worker_death'}
2017-04-03 13:30:38,660 - eventmq.jobmanager  DEBUG - {'return': {'value': 'I slept for 5 seconds'}, 'msgid': '2cea46f5-67e4-4a9d-adb9-e4ada3b317b2', 'pid': 32076, 'callback': 'worker_done_with_reply'}
2017-04-03 13:30:38,660 - eventmq.utils.classes  DEBUG - Sending message: ('', 'eMQP/1.0', 'REPLY', '481290bc-ce74-4d71-8bfd-84d542d4b534', '{"value": "I slept for 5 seconds"}', '2cea46f5-67e4-4a9d-adb9-e4ada3b317b2')
2017-04-03 13:30:38,660 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 32076, 'callback': 'worker_death'}
2017-04-03 13:30:38,661 - eventmq.jobmanager  DEBUG - {'return': {'value': 'I slept for 5 seconds'}, 'msgid': 'e4aa4dce-26df-44c6-b10f-733ce8e6902c', 'pid': 32075, 'callback': 'worker_done_with_reply'}
2017-04-03 13:30:38,661 - eventmq.utils.classes  DEBUG - Sending message: ('', 'eMQP/1.0', 'REPLY', 'b4451258-7e5e-461d-a40b-92d1d23c274b', '{"value": "I slept for 5 seconds"}', 'e4aa4dce-26df-44c6-b10f-733ce8e6902c')
2017-04-03 13:30:38,661 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 32075, 'callback': 'worker_death'}
```

timeout=None, job=test_jobmanager.work_job(50), SIGTERM 2 seconds after job starts with the kill unresponsive timeout tuned to 2 seconds (this one died cleanly after the 2 second period):
```2017-04-03 15:10:12,153 - eventmq.utils.classes  DEBUG - Received message: ['', 'eMQP/1.0', 'REQUEST', '34b39f65-27d2-425f-a07c-7f33ad1a450e', 'default', 'reply-requested,guarantee', '["run", {"args": [50], "class_args": ["blurp"], "callable": "work_job", "kwargs": {}, "path": "eventmq.tests.test_jobmanager", "class_kwargs": {"kwarg1": true}}]']
2017-04-03 15:10:12,155 - eventmq.worker.9556  DEBUG - _run
^C2017-04-03 15:10:14,374 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:10:14,374 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:10:14,374 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:10:14,374 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:10:14,385 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:10:14,386 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:10:14,386 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:10:14,386 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:10:14,386 - eventmq.worker.9554  DEBUG - Worker death
2017-04-03 15:10:14,387 - eventmq.worker.9555  DEBUG - Worker death
2017-04-03 15:10:14,387 - eventmq.worker.9553  DEBUG - Worker death
2017-04-03 15:10:14,486 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 9554, 'callback': 'worker_death'}
2017-04-03 15:10:14,487 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 9553, 'callback': 'worker_death'}
2017-04-03 15:10:14,487 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 9555, 'callback': 'worker_death'}
2017-04-03 15:10:16,390 - eventmq.jobmanager  DEBUG - Killing unresponsive workers
```

Same as above job, but with timeout=10, this respects the timeout specified and doesn't kill
```2017-04-03 15:14:10,503 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:14:10,503 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:14:10,503 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:14:10,503 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:14:10,503 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:14:10,514 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:14:10,514 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:14:10,514 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:14:10,515 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:14:10,515 - eventmq.worker.9749  DEBUG - Worker death
2017-04-03 15:14:10,515 - eventmq.worker.9750  DEBUG - Worker death
2017-04-03 15:14:10,520 - eventmq.worker.9752  DEBUG - Worker death
2017-04-03 15:14:10,615 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 9749, 'callback': 'worker_death'}
2017-04-03 15:14:10,615 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 9750, 'callback': 'worker_death'}
2017-04-03 15:14:10,615 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 9752, 'callback': 'worker_death'}
2017-04-03 15:14:18,430 - eventmq.jobmanager  DEBUG - {'return': 'TimeoutError', 'msgid': 'ef138e15-a45b-4a2c-9dab-979af5b78fee', 'pid': 9751, 'callback': 'worker_done_with_reply'}
2017-04-03 15:14:18,430 - eventmq.jobmanager  DEBUG - Worker done with reply
2017-04-03 15:14:18,431 - eventmq.utils.classes  DEBUG - Sending message: ('', 'eMQP/1.0', 'REPLY', '42e0a509-efb1-4be7-8548-ae99495957aa', '"TimeoutError"', 'ef138e15-a45b-4a2c-9dab-979af5b78fee')
2017-04-03 15:14:18,431 - eventmq.worker.9751  DEBUG - Worker death
2017-04-03 15:14:18,531 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 9751, 'callback': 'worker_death'}
```

job=work_job(50), timeout=None/10(2 of each), 4 requests then SIGTERM (the 2  timeout jobs respected timeout, the other waited and finished as 50 seconds is < configured kill grace period (300)
```2017-04-03 15:21:43,390 - eventmq.utils.classes  DEBUG - Received message: ['', 'eMQP/1.0', 'REQUEST', '14e68a12-af3e-4dce-88d3-7f6b0f8d44df', 'default', 'reply-requested,guarantee,timeout:10', '["run", {"args": [50], "class_args": ["blurp"], "callable": "work_job", "kwargs": {}, "path": "eventmq.tests.test_jobmanager", "class_kwargs": {"kwarg1": true}}]']
2017-04-03 15:21:43,393 - eventmq.utils.classes  DEBUG - Received message: ['', 'eMQP/1.0', 'REQUEST', 'c9025526-4b4d-42a9-aa68-add0958f6e1d', 'default', 'reply-requested,guarantee', '["run", {"args": [50], "class_args": ["blurp"], "callable": "work_job", "kwargs": {}, "path": "eventmq.tests.test_jobmanager", "class_kwargs": {"kwarg1": true}}]']
2017-04-03 15:21:44,055 - eventmq.utils.classes  DEBUG - Received message: ['', 'eMQP/1.0', 'REQUEST', '4af1d7df-8f5f-4bea-8f97-3b93eec67b9f', 'default', 'reply-requested,guarantee,timeout:10', '["run", {"args": [50], "class_args": ["blurp"], "callable": "work_job", "kwargs": {}, "path": "eventmq.tests.test_jobmanager", "class_kwargs": {"kwarg1": true}}]']
2017-04-03 15:21:44,063 - eventmq.utils.classes  DEBUG - Received message: ['', 'eMQP/1.0', 'REQUEST', '7fd5cd5b-00f3-4bbd-93c2-f54038d204dd', 'default', 'reply-requested,guarantee', '["run", {"args": [50], "class_args": ["blurp"], "callable": "work_job", "kwargs": {}, "path": "eventmq.tests.test_jobmanager", "class_kwargs": {"kwarg1": true}}]']
2017-04-03 15:21:53,446 - eventmq.jobmanager  DEBUG - {'return': 'TimeoutError', 'msgid': '14e68a12-af3e-4dce-88d3-7f6b0f8d44df', 'pid': 10616, 'callback': 'worker_done_with_reply'}
2017-04-03 15:21:53,446 - eventmq.utils.classes  DEBUG - Sending message: ('', 'eMQP/1.0', 'REPLY', '97ed153b-33b2-4343-93f6-87bbcce36eb5', '"TimeoutError"', '14e68a12-af3e-4dce-88d3-7f6b0f8d44df')
2017-04-03 15:21:54,092 - eventmq.jobmanager  DEBUG - {'return': 'TimeoutError', 'msgid': '4af1d7df-8f5f-4bea-8f97-3b93eec67b9f', 'pid': 10615, 'callback': 'worker_done_with_reply'}
2017-04-03 15:21:54,093 - eventmq.utils.classes  DEBUG - Sending message: ('', 'eMQP/1.0', 'REPLY', '78df4ffa-6649-493a-8d07-0d51dde7f95f', '"TimeoutError"', '4af1d7df-8f5f-4bea-8f97-3b93eec67b9f')
^C2017-04-03 15:21:54,849 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:21:54,849 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:21:54,851 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:21:54,860 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:21:54,860 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:21:54,860 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:21:54,860 - eventmq.jobmanager  DEBUG - Requesting worker death
2017-04-03 15:21:54,955 - eventmq.worker.10615  DEBUG - Worker death
2017-04-03 15:21:54,961 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 10615, 'callback': 'worker_death'}
2017-04-03 15:21:55,014 - eventmq.worker.10616  DEBUG - Worker death
2017-04-03 15:21:55,061 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 10616, 'callback': 'worker_death'}
2017-04-03 15:22:33,394 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:22:33,395 - eventmq.worker.10613  DEBUG - Worker death
2017-04-03 15:22:33,438 - eventmq.jobmanager  DEBUG - {'return': {'value': 2}, 'msgid': 'c9025526-4b4d-42a9-aa68-add0958f6e1d', 'pid': 10613, 'callback': 'worker_done_with_reply'}
2017-04-03 15:22:33,438 - eventmq.utils.classes  DEBUG - Sending message: ('', 'eMQP/1.0', 'REPLY', '307f1f55-81fe-4b5c-b0df-2ac3bcdf6715', '{"value": 2}', 'c9025526-4b4d-42a9-aa68-add0958f6e1d')
2017-04-03 15:22:33,439 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 10613, 'callback': 'worker_death'}
2017-04-03 15:22:34,064 - eventmq.jobmanager  INFO - Shutting down..
2017-04-03 15:22:34,065 - eventmq.worker.10614  DEBUG - Worker death
2017-04-03 15:22:34,140 - eventmq.jobmanager  DEBUG - {'return': {'value': 2}, 'msgid': '7fd5cd5b-00f3-4bbd-93c2-f54038d204dd', 'pid': 10614, 'callback': 'worker_done_with_reply'}
2017-04-03 15:22:34,141 - eventmq.utils.classes  DEBUG - Sending message: ('', 'eMQP/1.0', 'REPLY', 'c52d317b-a6e5-4b5d-b7e7-df7d06926512', '{"value": 2}', '7fd5cd5b-00f3-4bbd-93c2-f54038d204dd')
2017-04-03 15:22:34,141 - eventmq.jobmanager  DEBUG - {'return': 'DEATH', 'msgid': None, 'pid': 10614, 'callback': 'worker_death'}
```