### PR TITLE
Fixes a bunch of worker logic, add docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.4',
+    version='0.3.4.1',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
# What
Logic cleanup, adds premature_death callback when no jobs run on the worker before death. Adds documentation.  Adds a send_ready on worker_death callback if we're still running.

# Tests
I wrote a system test seperately and results so far are good - not ready to merge that and this fix is critical