### PR TITLE
Make the worker thread the only thread that runs setup/worker code

### DIFF
--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.4'
+__version__ = '0.3.4.2'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -222,6 +222,7 @@ class JobManager(HeartbeatMixin, EMQPService):
 
         """
 
+        logger.debug(resp)
         pid = resp['pid']
 
         callback = getattr(self, resp['callback'])
@@ -302,13 +303,16 @@ class JobManager(HeartbeatMixin, EMQPService):
             reply = {"value": str(e)}
 
         self.send_reply(reply, msgid)
-        self.send_ready()
+
+        if self.status != STATUS.stopping:
+            self.send_ready()
 
     def worker_done(self, reply, msgid):
         """
         Worker finished a job, notify broker of an additional slot opening
         """
-        self.send_ready()
+        if self.status != STATUS.stopping:
+            self.send_ready()
 
     def send_ready(self):
         """

--- a/eventmq/tests/test_worker.py
+++ b/eventmq/tests/test_worker.py
@@ -39,7 +39,7 @@ def test_run_with_timeout():
         'args': [2]
     }
 
-    msgid = worker._run(payload, logging.getLogger())
+    msgid = worker._run_job(payload, logging.getLogger())
 
     assert msgid
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.4.1',
+    version='0.3.4.2',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
# What
We want the same thread that ran the setup to run the worker code in case there are thread-specific variables such as db connections, etc.

# Why
To avoid duplicating certain thread-level variables

# Tests
System tested with and without timeout, sent SIGTERM during job execution