### PR TITLE
Fix timeout error bug causing extra slots

### DIFF
--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.4.4'
+__version__ = '0.3.4.5'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -129,7 +129,7 @@ class MultiprocessWorker(Process):
                         {'msgid': msgid,
                          'return': return_val,
                          'death': self.job_count >= conf.MAX_JOB_COUNT or
-                         return_val == 'TimeoutError',
+                         return_val["value"] == 'TimeoutError',
                          'pid': os.getpid(),
                          'callback': callback}
                     )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.4.4',
+    version='0.3.4.5',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
# What
Signal's death and therefore no ready signal when a TimeoutError occurs.  This was causing workers with Timeouts to send an extra READY each time.  

# Tests
Locally:
Sent 4 jobs that purposefully timeout on a jobmanager with 4 slots -> saw it increase to 8 erroneously.  Tried again with this fix and it stayed at 4 as expected.