### PR TITLE
SIGHUP handling

### DIFF
--- a/eventmq/tests/test_jobmanager.py
+++ b/eventmq/tests/test_jobmanager.py
@@ -55,8 +55,11 @@ class TestCase(unittest.TestCase):
     def test__start_event_loop(self, maybe_send_hb_mock,
                                poll_mock, sender_mock, process_msg_mock,
                                pool_close_mock):
+
+        # Create a jobmanager with no child processes for testing
         jm = jobmanager.JobManager(override_settings={
-            'CONNECT_ADDR': ADDR
+            'CONNECT_ADDR': ADDR,
+            'CONCURRENT_JOBS': 0,
         })
         maybe_send_hb_mock.return_value = False
         poll_mock.return_value = {jm.frontend: jobmanager.POLLIN}

--- a/eventmq/utils/classes.py
+++ b/eventmq/utils/classes.py
@@ -182,6 +182,7 @@ class EMQPService(object):
         Resets the current connection by closing and reopening the socket
         """
         # Unregister the old socket from the poller
+        logger.debug("Resetting Jobmanager")
         self.poller.unregister(self.frontend)
 
         # Polish up a new socket to use
@@ -189,6 +190,9 @@ class EMQPService(object):
 
         # Prepare the device to connect again
         self._setup()
+
+        # Start the jobmanager again
+        self.start()
 
     def process_message(self, msg):
         """

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -109,16 +109,12 @@ class MultiprocessWorker(Process):
                 timeout = payload.get("timeout") or conf.GLOBAL_TIMEOUT
                 msgid = payload.get('msgid', '')
                 callback = payload.get('callback', '')
-                logger.debug("Putting on thread queue msgid: {}".format(
-                    msgid))
 
                 worker_queue.put(payload['params'])
 
                 try:
                     return_val = worker_result_queue.get(timeout=timeout)
 
-                    logger.debug("Got from result queue msgid: {}".format(
-                        msgid))
                 except Queue.Empty:
                     return_val = 'TimeoutError'
 
@@ -129,7 +125,7 @@ class MultiprocessWorker(Process):
                         {'msgid': msgid,
                          'return': return_val,
                          'death': self.job_count >= conf.MAX_JOB_COUNT or
-                         return_val == 'TimeoutError',
+                         return_val["value"] == 'TimeoutError',
                          'pid': os.getpid(),
                          'callback': callback}
                     )


### PR DESCRIPTION
# What

SIGHUP Handling according to Issue #2 
This meets all requirements except the SHOULD keep job processes alive if possible.  Thoughts on that requirement as its unclear whether that will actually reload any imported modules or release any held resources such as db connections, files, etc?

Also - this should backport cleanly into 0.3 if requested.

# Tests
Jobmanager with 4 slots: Send 8 messages, 4 destined to Timeout, 4 that will finish with no timeout specified.  While the jobmanager is processing, send a SIGHUP.  Observer the manager loads new config, reconnects, reports 8 REPLY's sent and 12 READY's sent.

https://gist.github.com/sideshowdave7/f806687b09bc902987b5e6dcc2e9b328

I'm also working on recreating the system level test, and this will be a perfect candidate for that.
