### PR TITLE
Ensure a new uuid is generated each time a sender disconnects and tries reconnecting

### DIFF
--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.4.5'
+__version__ = '0.3.4.6'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/sender.py
+++ b/eventmq/sender.py
@@ -138,6 +138,9 @@ class Sender(ZMQSendMixin, ZMQReceiveMixin):
             self.zsocket.close()
 
         self.zsocket = kwargs.pop('socket', self.zcontext.socket(zmq.DEALER))
+
+        self.name = kwargs.pop('name', str(uuid.uuid4()))
+
         if sys.version[0] == '2':
             self.zsocket.setsockopt(zmq.IDENTITY, self.name)
         else:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.4.5',
+    version='0.3.4.6',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
# What
This allows workers to quickly disconnect and reconnect, and recover from network failures.  ZMQ_ROUTER_HANDOVER on the router defaults to trying to use the original socket when a peer connects with the same Identity which can prevent a quick reconnect with a new socket.

This will eventually be in 0.4 with hostname:uuid format.

# Tests Done
start router/broker on loopback interface, they connect
shutdown the loopback network interface, observer disconnect after HEARTBEAT_LIVENESS passes
start the loopback interface up again, observer reconnect with new uuid.