### PR TITLE
Feature/super debug cleanup

### DIFF
--- a/docs/settings_file.rst
+++ b/docs/settings_file.rst
@@ -30,6 +30,20 @@ Default: 'tcp://127.0.0.1:47291'
 
 The address used to listen for connections from workers
 
+wal
+=======
+Default: '/var/log/eventmq/wal.log'
+
+Write-ahead Log for replaying messages received by the Router.  Will
+try to create the directory specified and append to the filename given.
+Requires correct permissions to write to the given file.
+
+wal_enabled
+===============
+Default: False
+
+Enable or disable the Write-ahead Log
+
 *********
 Scheduler
 *********

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.4.6'
+__version__ = '0.3.4.7'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -97,4 +97,7 @@ SETUP_CALLABLE = ''
 KILL_GRACE_PERIOD = 300
 GLOBAL_TIMEOUT = 300
 
+WAL_LOG = '/var/log/eventmq/wal.log'
+WAL_LOG_ENABLED = False
+
 # }}}

--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -97,7 +97,7 @@ SETUP_CALLABLE = ''
 KILL_GRACE_PERIOD = 300
 GLOBAL_TIMEOUT = 300
 
-WAL_LOG = '/var/log/eventmq/wal.log'
-WAL_LOG_ENABLED = False
+WAL = '/var/log/eventmq/wal.log'
+WAL_ENABLED = False
 
 # }}}

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -240,7 +240,8 @@ class JobManager(HeartbeatMixin, EMQPService):
 
         """
 
-        logger.debug(resp)
+        if conf.SUPER_DEBUG:
+            logger.debug(resp)
         pid = resp['pid']
         msgid = resp['msgid']
         callback = resp['callback']
@@ -383,9 +384,10 @@ class JobManager(HeartbeatMixin, EMQPService):
         necessary
         """
         # Kill workers that aren't alive
-        logger.debug("Jobs in flight: {}".format(len(self.jobs_in_flight)))
-        logger.debug("Total requests: {}".format(self.total_requests))
-        logger.debug("Total ready sent: {}".format(self.total_ready_sent))
+        if conf.SUPER_DEBUG:
+            logger.debug("Jobs in flight: {}".format(len(self.jobs_in_flight)))
+            logger.debug("Total requests: {}".format(self.total_requests))
+            logger.debug("Total ready sent: {}".format(self.total_ready_sent))
         try:
             [self.kill_worker(w.pid, signal.SIGKILL) for w in self.workers
              if not w.is_alive]

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -186,9 +186,9 @@ class JobManager(HeartbeatMixin, EMQPService):
                     else:
                         try:
                             events = self.poller.poll(1000)
-                        except zmq.ZMQError:
+                        except zmq.ZMQError as e:
                             logger.debug('Disconnecting due to ZMQError while'
-                                         ' polling')
+                                         ' polling: {}'.format(e))
                             sendmsg(self.outgoing, KBYE)
                             self.received_disconnect = True
                             continue

--- a/eventmq/router.py
+++ b/eventmq/router.py
@@ -709,7 +709,7 @@ class Router(HeartbeatMixin):
 
         command = message[1]
 
-        if conf.WAL_LOG_ENABLED and \
+        if conf.WAL_ENABLED and \
            command in ("REQUEST", "SCHEDULE", "UNSCHEDULE"):
             wal_logger.info(original_msg)
 
@@ -934,7 +934,7 @@ class Router(HeartbeatMixin):
         """
         setup_logger('eventmq')
         import_settings()
-        setup_wal_logger('eventmq-wal', conf.WAL_LOG)
+        setup_wal_logger('eventmq-wal', conf.WAL)
         self.start(frontend_addr=conf.FRONTEND_ADDR,
                    backend_addr=conf.BACKEND_ADDR,
                    administrative_addr=conf.ADMINISTRATIVE_ADDR)

--- a/eventmq/router.py
+++ b/eventmq/router.py
@@ -179,7 +179,8 @@ class Router(HeartbeatMixin):
 
             if events.get(self.administrative_socket) == poller.POLLIN:
                 msg = self.administrative_socket.recv_multipart()
-                logger.debug('ADMIN: {}'.format(msg))
+                if conf.SUPER_DEBUG:
+                    logger.debug('ADMIN: {}'.format(msg))
                 # ##############
                 # Admin Commands
                 # ##############
@@ -331,8 +332,9 @@ class Router(HeartbeatMixin):
         """
 
         orig_msgid = msg[1]
-        logger.info('Received REPLY from {} (msgid: {}, ACK msgid: {})'.format(
-            sender, msgid, orig_msgid))
+        if conf.SUPER_DEBUG:
+            logger.debug('Received REPLY from {} (msgid: {}, ACK msgid: {})'.
+                         format(sender, msgid, orig_msgid))
 
         if orig_msgid in self.job_latencies:
             elapsed_secs = (monotonic()

--- a/eventmq/utils/classes.py
+++ b/eventmq/utils/classes.py
@@ -345,10 +345,9 @@ class ZMQReceiveMixin(object):
         Receive a message
         """
         msg = self.zsocket.recv()
-        if conf.SUPER_DEBUG:
-            if not ("HEARTBEAT" == msg[2] or "HEARTBEAT" == msg[3]) or \
-               not conf.HIDE_HEARTBEAT_LOGS:
-                logger.debug('Received message: {}'.format(msg))
+        if not ("HEARTBEAT" == msg[2] or "HEARTBEAT" == msg[3]) or \
+                not conf.HIDE_HEARTBEAT_LOGS:
+            logger.debug('Received message: {}'.format(msg))
         return msg
 
     def recv_multipart(self):
@@ -356,13 +355,12 @@ class ZMQReceiveMixin(object):
         Receive a multipart message
         """
         msg = self.zsocket.recv_multipart()
-        if conf.SUPER_DEBUG:
-            # If it's not at least 4 frames long then most likely it isn't an
-            # eventmq message
-            if len(msg) >= 4 and \
-               not ("HEARTBEAT" == msg[2] or "HEARTBEAT" == msg[3]) or \
-               not conf.HIDE_HEARTBEAT_LOGS:
-                logger.debug('Received message: {}'.format(msg))
+        # If it's not at least 4 frames long then most likely it isn't an
+        # eventmq message
+        if len(msg) >= 4 and \
+            not ("HEARTBEAT" == msg[2] or "HEARTBEAT" == msg[3]) or \
+                not conf.HIDE_HEARTBEAT_LOGS:
+            logger.debug('Received message: {}'.format(msg))
         return msg
 
 
@@ -402,13 +400,12 @@ class ZMQSendMixin(object):
 
         msg = encodify(headers + message)
 
-        if conf.SUPER_DEBUG:
-            # If it's not at least 4 frames long then most likely it isn't an
-            # eventmq message
-            if len(msg) > 4 and \
-               not ("HEARTBEAT" == msg[2] or "HEARTBEAT" == msg[3]) or \
-               not conf.HIDE_HEARTBEAT_LOGS:
-                logger.debug('Sending message: %s' % str(msg))
+        # If it's not at least 4 frames long then most likely it isn't an
+        # eventmq message
+        if len(msg) > 4 and \
+            not ("HEARTBEAT" == msg[2] or "HEARTBEAT" == msg[3]) or \
+                not conf.HIDE_HEARTBEAT_LOGS:
+            logger.debug('Sending message: %s' % str(msg))
 
         try:
             self.zsocket.send_multipart(msg,

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -109,16 +109,19 @@ class MultiprocessWorker(Process):
                 timeout = payload.get("timeout") or conf.GLOBAL_TIMEOUT
                 msgid = payload.get('msgid', '')
                 callback = payload.get('callback', '')
-                logger.debug("Putting on thread queue msgid: {}".format(
-                    msgid))
+
+                if conf.SUPER_DEBUG:
+                    logger.debug("Putting on thread queue msgid: {}".format(
+                        msgid))
 
                 worker_queue.put(payload['params'])
 
                 try:
                     return_val = worker_result_queue.get(timeout=timeout)
 
-                    logger.debug("Got from result queue msgid: {}".format(
-                        msgid))
+                    if conf.SUPER_DEBUG:
+                        logger.debug("Got from result queue msgid: {}".format(
+                            msgid))
                 except Queue.Empty:
                     return_val = 'TimeoutError'
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.4.6',
+    version='0.3.4.7',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
Adds a WAL log implementation for the router with 2 options:

WAL='/path/to/wal/log': Will attempt to create the directory and file, or append if it exists.
WAL_ENABLED=True/False (Enables or disables the WAL)

Cleans up a lot of logging to SUPER_DEBUG only.  Super debug/WAL only contains messages related to message traffic (data path).  Control path signals have been moved to DEBUG or higher.
