### PR TITLE
Send ready every time the event loop starts now that the worker IDENT…

### DIFF
--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.4.7'
+__version__ = '0.3.4.8'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -146,7 +146,9 @@ class JobManager(HeartbeatMixin, EMQPService):
         Starts the actual event loop. Usually called by :meth:`start`
         """
         # Acknowledgment has come
-        # Send a READY for each available worker
+        # Send a READY for each previously available worker
+        for _ in self.workers:
+            self.send_ready()
 
         self.status = STATUS.running
 

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -146,9 +146,13 @@ class JobManager(HeartbeatMixin, EMQPService):
         Starts the actual event loop. Usually called by :meth:`start`
         """
         # Acknowledgment has come
+        # When the job manager unexpectedly disconnects from the router and
+        # reconnects it needs to send a ready for each previously available
+        # worker.
         # Send a READY for each previously available worker
-        for _ in self.workers:
-            self.send_ready()
+        if hasattr(self, '_workers'):
+            for _ in self._workers:
+                self.send_ready()
 
         self.status = STATUS.running
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.4.7',
+    version='0.3.4.8',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
…ITY changes everytime

Now that we change the uuid portion of the zmq.IDENTITY on every single attempted reconnect, the broker no longer can keep track of any outstanding READY commands from the old worker that dropped off.  This ensures we send READY for each slot after a reconnect.