### PR TITLE
Fix bug in scheduler; Optimize scheduler code a bit 

### DIFF
--- a/eventmq/router.py
+++ b/eventmq/router.py
@@ -175,15 +175,6 @@ class Router(HeartbeatMixin):
             now = monotonic()
             events = self.poller.poll()
 
-            if events.get(self.incoming) == poller.POLLIN:
-                msg = self.incoming.recv_multipart()
-                self.handle_wal_log(msg)
-                self.process_client_message(msg)
-
-            if events.get(self.outgoing) == poller.POLLIN:
-                msg = self.outgoing.recv_multipart()
-                self.process_worker_message(msg)
-
             if events.get(self.administrative_socket) == poller.POLLIN:
                 msg = self.administrative_socket.recv_multipart()
                 if conf.SUPER_DEBUG:
@@ -206,6 +197,15 @@ class Router(HeartbeatMixin):
                     elif msg[3] == ROUTER_SHOW_SCHEDULERS:
                         sendmsg(self.administrative_socket, msg[0], 'REPLY',
                                 (self.get_schedulers_status(),))
+
+            if events.get(self.incoming) == poller.POLLIN:
+                msg = self.incoming.recv_multipart()
+                self.handle_wal_log(msg)
+                self.process_client_message(msg)
+
+            if events.get(self.outgoing) == poller.POLLIN:
+                msg = self.outgoing.recv_multipart()
+                self.process_worker_message(msg)
 
             # TODO: Optimization: the calls to functions could be done in
             #     another thread so they don't block the loop. synchronize

--- a/eventmq/utils/timeutils.py
+++ b/eventmq/utils/timeutils.py
@@ -63,19 +63,23 @@ class IntervalIter(object):
         next(interval)  # 300
         next(interval)  # 600
     """
-    def __init__(self, start_value, interval_secs):
+    def __init__(self, start_value, interval_secs, iterate_immediately=False):
         """
         Args:
-            start_value (numeric) - the timestamp to begin with. usually gotten
+            start_value (numeric): the timestamp to begin with. usually gotten
                 via :func:`monotonic` or :func:`timestamp`
-            interval_secs (int) - the number of seconds between intervals
+            interval_secs (int): the number of seconds between intervals
+            iterate_immediately (bool): When this is ``True`` the value of this
+                iterator will increase ``start_value`` by ``interval_secs``
+                immediately. *Default is False*
         """
         self.current = start_value
         self.interval_secs = interval_secs
 
         # iterate the first time so the first call to .next() is interval_secs
         # + start_value
-        self.__next__()
+        if iterate_immediately:
+            self.__next__()
 
     def __iter__(self):
         return self


### PR DESCRIPTION
- Fixes a bug when cancelling schedules due to run count. The schedule
  cancelled weren't the schedules that were marked for cancellation,
  but the schedule that was last checked to see if it needed to be
  executed. (use `job_id` from the cancellation loop instead of the job
  id from the previous look `k`)
- Consolidate the job cancellation logic. The main loop and
  `unschedule` both implemented the same logic. This was consolidated
  into a new `cancel_job` method
- Optimize the main loop a bit. If `run_count` is 0 then don't write
  to redis and cancel on the next loop. Instead just cancel the
  schedule.