### PR TITLE
Fix bug in router with python2

### DIFF
--- a/eventmq/utils/classes.py
+++ b/eventmq/utils/classes.py
@@ -362,7 +362,7 @@ class ZMQReceiveMixin(object):
         msg = self.zsocket.recv_multipart()
 
         # Decode bytes to strings in python3
-        if type(msg[0] in (bytes,)):
+        if sys.version[0] == '3' and type(msg[0] in (bytes,)):
             msg = [m.decode() for m in msg]
 
         # If it's not at least 4 frames long then most likely it isn't an


### PR DESCRIPTION
- This code seems to have been added awhile ago, but never really
  tested in python 2. We shouldn't convert strings to unicode in
  python 2 when receiving messages. This causes a TypeError when
  forwarding messages:
  ```
  TypeError: Frame 0 (u'719ff6da-ac33-4273-a2bc-6cb9b4...) does not
  support the buffer interface.
  ```

References: 55963796809ce5aacf47c24d8295ab5b1a500ad1