### PR TITLE
Add arguments to the scheduler and router

### DIFF
--- a/bin/emq-router
+++ b/bin/emq-router
@@ -1,8 +1,20 @@
 #!/usr/bin/env python
 # -*- mode: python -*-
+import argparse
+
 from eventmq.log import setup_logger
 from eventmq.router import Router
 
 if __name__ == "__main__":
+	parser = argparse.ArgumentParser(
+	    description='Route job messages to their appropriate queues')
+	parser.add_argument('--config', '-C', type=str, nargs='?',
+                        help='manually specify the location of eventmq.conf')
+
+	args = parser.parse_args()
+
+	if args.config:
+	    conf.CONFIG_FILE = args.config
+
     r = Router()
     r.router_main()

--- a/bin/emq-scheduler
+++ b/bin/emq-scheduler
@@ -1,7 +1,18 @@
 #!/usr/bin/env python
 # -*- mode: python -*-
+import argparse
 from eventmq.scheduler import Scheduler
 
 if __name__ == "__main__":
+	parser = argparse.ArgumentParser(
+	    description='Listen for scheduled jobs and run them')
+	parser.add_argument('--config', '-C', type=str, nargs='?',
+                        help='manually specify the location of eventmq.conf')
+
+	args = parser.parse_args()
+
+	if args.config:
+	    conf.CONFIG_FILE = args.config
+
     s = Scheduler()
     s.scheduler_main()


### PR DESCRIPTION
- Add `--config` flags to the scheduler and router for consistency across processes