### PR TITLE
 Add job setup and cleanup functions 

### DIFF
--- a/etc/eventmq.conf-dist
+++ b/etc/eventmq.conf-dist
@@ -27,13 +27,13 @@ queues=[[20,"heavy-cpu"], [30,"low-cpu"], [10,"default"]]
 concurrent_jobs=2
 
 # This function is executed when EventMQ creates a new worker subprocess
-# subprocess_setup_func = 'path.to.my_setup_function'
+# subprocess_setup_func = path.to.my_setup_function
 
 # This function is executed before every job
-# job_entry_func = 'path.to.my_job_setup_function'
+# job_entry_func = path.to.my_job_setup_function
 
 # This function is executed after every job
-# job_exit_func = 'path.to.my_job_teardown_function'
+# job_exit_func = path.to.my_job_teardown_function
 
 [publisher]
 publisher_incoming_addr=tcp://0.0.0.0:47298

--- a/etc/eventmq.conf-dist
+++ b/etc/eventmq.conf-dist
@@ -19,8 +19,21 @@ scheduler_addr=tcp://eventmq:47291
 
 [jobmanager]
 worker_addr=tcp://127.0.0.1:47290
-queues=[[50,"google"], [40,"pushes"], [10,"default"]]
+
+# Defines the weight and name of queues this worker deals with.
+queues=[[20,"heavy-cpu"], [30,"low-cpu"], [10,"default"]]
+
+# Specifies the number of of sub-processes to spawn to process jobs concurrently
 concurrent_jobs=2
+
+# This function is executed when EventMQ creates a new worker subprocess
+# subprocess_setup_func = 'path.to.my_setup_function'
+
+# This function is executed before every job
+# job_entry_func = 'path.to.my_job_setup_function'
+
+# This function is executed after every job
+# job_exit_func = 'path.to.my_job_teardown_function'
 
 [publisher]
 publisher_incoming_addr=tcp://0.0.0.0:47298

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.5.6'
+__version__ = '0.3.6'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -89,9 +89,18 @@ RQ_PASSWORD = ''
 MAX_JOB_COUNT = 1024
 
 # Path/Callable to run on start of a worker process
+# These options are deprecated for the more user-friendly
+# SUBPROCESS_SETUP_FUNC which can be a full path to a function.
 SETUP_PATH = ''
 SETUP_CALLABLE = ''
 
+# Function to run on the start of a new worker subprocess
+SUBPROCESS_SETUP_FUNC = ''
+
+# function to be run before the execution of every job
+JOB_ENTRY_FUNC = ''
+# function to be run after the execution of every job
+JOB_EXIT_FUNC = ''
 # Time to wait after receiving SIGTERM to kill the workers in the jobmanager
 # forecfully
 KILL_GRACE_PERIOD = 300

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -29,6 +29,7 @@ import time
 import zmq
 
 from eventmq.log import setup_logger
+from . import __version__
 from . import conf
 from .constants import KBYE, STATUS
 from .poller import Poller, POLLIN
@@ -80,6 +81,7 @@ class JobManager(HeartbeatMixin, EMQPService):
         #: Define the name of this JobManager instance. Useful to know when
         #: referring to the logs.
         self.name = kwargs.pop('name', None) or generate_device_name()
+        logger.info('EventMQ Version {}'.format(__version__))
         logger.info('Initializing JobManager {}...'.format(self.name))
 
         #: keep track of workers

--- a/eventmq/router.py
+++ b/eventmq/router.py
@@ -23,6 +23,7 @@ import logging
 import signal
 
 from eventmq.log import setup_logger, setup_wal_logger
+from . import __version__
 from . import conf, constants, exceptions, poller, receiver
 from .constants import (
     CLIENT_TYPE, DISCONNECT, KBYE, PROTOCOL_VERSION, ROUTER_SHOW_SCHEDULERS,
@@ -51,8 +52,11 @@ class Router(HeartbeatMixin):
     def __init__(self, *args, **kwargs):
         super(Router, self).__init__(*args, **kwargs)  # Creates _meta
 
+        setup_logger("eventmq")
+
         self.name = generate_device_name()
-        logger.info('Initializing Router %s...' % self.name)
+        logger.info('EventMQ Version {}'.format(__version__))
+        logger.info('Initializing Router {}...'.format(self.name))
 
         self.poller = poller.Poller()
 
@@ -943,7 +947,6 @@ class Router(HeartbeatMixin):
         """
         Kick off router with logging and settings import
         """
-        setup_logger('eventmq')
         import_settings()
         setup_wal_logger('eventmq-wal', conf.WAL)
         self.start(frontend_addr=conf.FRONTEND_ADDR,

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -29,6 +29,7 @@ from six import next
 
 from eventmq.log import setup_logger
 
+from . import __version__
 from . import conf, constants
 from .client.messages import send_request
 from .constants import KBYE
@@ -53,6 +54,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
     def __init__(self, *args, **kwargs):
         self.name = kwargs.get('name', None)
 
+        logger.info('EventMQ Version {}'.format(__version__))
         logger.info('Initializing Scheduler...')
         import_settings()
         super(Scheduler, self).__init__(*args, **kwargs)

--- a/eventmq/tests/test_worker.py
+++ b/eventmq/tests/test_worker.py
@@ -14,10 +14,11 @@
 # along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import time
 import sys
+import time
 
 import mock
+
 from .. import worker
 
 if sys.version[0] == '2':
@@ -28,6 +29,7 @@ else:
 
 ADDR = 'inproc://pour_the_rice_in_the_thing'
 SETUP_SUCCESS_RETVAL = 'job setup success'
+
 
 def test_run_with_timeout():
     payload = {
@@ -168,15 +170,12 @@ def job(sleep_time=0):
 
 
 def process_setup_hook():
-    print 'process setup hook executed'
     return True
 
 
 def job_setup_hook():
-    print 'job setup hook executed'
     return SETUP_SUCCESS_RETVAL
 
 
 def job_teardown_hook():
-    print 'job teardown hook executed'
     return True

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -24,8 +24,8 @@ import os
 import sys
 from threading import Thread
 
-from .utils.functions import callable_from_name
 from . import conf
+from .utils.functions import callable_from_name
 
 if sys.version[0] == '2':
     import Queue

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.5.6',
+    version='0.3.6',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
This adds 2 new config options: `job_entry_func` and `job_exit_func`.
These functions are executed before and after every single job
execution. The rationale behind this is before and after each request
Django cleans up stale database connections, so Django jobs need some
way of running this same setup/cleanup functions.

https://github.com/django/django/blob/master/django/db/__init__.py#L57

```python
# Register an event to reset transaction state and close connections past
# their lifetime.
def close_old_connections(**kwargs):
    for conn in connections.all():
        conn.close_if_unusable_or_obsolete()

signals.request_started.connect(close_old_connections)
signals.request_finished.connect(close_old_connections)
```

fixes: #61 