### PR TITLE
Add an option to define max sockets per context

### DIFF
--- a/docs/settings_file.rst
+++ b/docs/settings_file.rst
@@ -13,6 +13,12 @@ Default: False
 
 Enable most verbose level of debug statements
 
+max_sockets
+===========
+Default: 1024
+
+Define the max sockets for a process/context
+
 ******
 Router
 ******

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.6'
+__version__ = '0.3.7'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -26,6 +26,9 @@ SUPER_DEBUG = False
 #: Default: True
 HIDE_HEARTBEAT_LOGS = True
 
+#: The maximum number of sockets to open per-process/context
+MAX_SOCKETS = 1024
+
 # When a queue name isn't specified use this queue name for the default. It
 # would be a good idea to have a handful of workers listening on this queue
 # unless you're positive that everything specifies a queue with workers.

--- a/eventmq/receiver.py
+++ b/eventmq/receiver.py
@@ -21,7 +21,7 @@ import logging
 
 import zmq
 
-from . import constants
+from . import conf, constants
 from .utils.classes import ZMQReceiveMixin, ZMQSendMixin
 from .utils.devices import generate_device_name
 
@@ -53,7 +53,12 @@ class Receiver(ZMQReceiveMixin, ZMQSendMixin):
         Raises:
             :class:`TypeError`: when `callable` is not callable
         """
+        from .utils import settings
+        settings.import_settings()
+
         self.zcontext = kwargs.get('context', zmq.Context.instance())
+        self.zcontext.set(zmq.MAX_SOCKETS, conf.MAX_SOCKETS)
+
         self.name = kwargs.get('name', generate_device_name())
 
         self.zsocket = kwargs.get('socket', self.zcontext.socket(zmq.ROUTER))

--- a/eventmq/sender.py
+++ b/eventmq/sender.py
@@ -23,7 +23,7 @@ import uuid
 
 import zmq
 
-from . import constants, exceptions
+from . import conf, constants, exceptions
 from .utils.classes import ZMQReceiveMixin, ZMQSendMixin
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,11 @@ class Sender(ZMQSendMixin, ZMQReceiveMixin):
                 socket
 
         """
+        from .utils import settings
+        settings.import_settings()
+
         self.zcontext = kwargs.pop('context', zmq.Context.instance())
+        self.zcontext.set(zmq.MAX_SOCKETS, conf.MAX_SOCKETS)
 
         # Set zsocket to none so we can check if it exists and close it before
         # rebuilding it later.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3.6',
+    version='0.3.7',
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
We are hitting the limit of max sockets open per context. This allows users to increase that limit when sending eventmq messages.