### PR TITLE
Add Python 2/3 Compatibility with configparser

### DIFF
--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.10-rc1'
+__version__ = '0.3.10'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/tests/test_utils.py
+++ b/eventmq/tests/test_utils.py
@@ -12,7 +12,16 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
-from configparser import ConfigParser
+
+#
+
+# ConfigParser was renamed to configparser in python 3. Do this try...except
+# to maintain python 2/3 compatability
+try:
+    from configparser import ConfigParser
+except ImportError:
+    import ConfigParser
+
 from imp import reload
 import io
 import os

--- a/eventmq/utils/settings.py
+++ b/eventmq/utils/settings.py
@@ -16,7 +16,14 @@
 :mod:`settings` -- Settings Utilities
 =====================================
 """
-from configparser import ConfigParser, NoOptionError
+
+# ConfigParser was renamed to configparser in python 3. Do this try...except
+# to maintain python 2/3 compatability
+try:
+    from configparser import ConfigParser, NoOptionError
+except ImportError:
+    from ConfigParser import ConfigParser, NoOptionError
+
 import json
 import logging
 import os


### PR DESCRIPTION
What
-----
- Add python 2/3 compatibility with confgparser

Why
----
- When installing the event module in our monolith, the eventmq util methods would break if this dependency was not included by another package