### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,3 +41,9 @@ workflows:
       - test:
           name: "python 3.5"
           version: "3.5"
+      - test:
+          name: "python 3.6"
+          version: "3.5"
+      - test:
+          name: "python 3.7"
+          version: "3.5"

--- a/bin/logwatcher.py
+++ b/bin/logwatcher.py
@@ -13,4 +13,4 @@ while True:
 
     if events.get(s) == zmq.POLLIN:
         msg = s.recv_multipart()
-        print msg  # noqa
+        print(msg)  # noqa

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.10'
+__version__ = '0.3.11'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/client/jobs.py
+++ b/eventmq/client/jobs.py
@@ -59,7 +59,7 @@ class Job(object):
            s.sendmail('me@gmail.com', [recipient,], msg.as_string())
            s.quit()
     """
-    def __init__(self, broker_addr=None, queue=None, async=True, *args,
+    def __init__(self, broker_addr=None, queue=None, async_=True, *args,
                  **kwargs):
         """
         Args:
@@ -69,20 +69,20 @@ class Job(object):
                 address is given then the value of the environment variable
                 ``EMQ_BROKER_ADDR`` will be used, If that is undefined a
                 warning will be emitted and the job will be run synchronously.
-            async (bool): If you want to run all executions of a particular job
-                synchronously but still decorate it with the job decorator you
-                can set this to False. This is useful for unit tests.
+            async_ (bool): If you want to run all executions of a particular
+                job synchronously but still decorate it with the job decorator
+                you can set this to False. This is useful for unit tests.
 
         """
         # conf.BROKER_ADDR isn't used because /etc/eventmq.conf is for the
         # daemons.
         self.broker_addr = broker_addr or os.environ.get(ENV_BROKER_ADDR)
         self.queue = queue
-        self.async = async
+        self.async_ = async_
 
     def __call__(self, f):
         def delay(*args, **kwargs):
-            if self.async and self.broker_addr:
+            if self.async_ and self.broker_addr:
                 socket = Sender()
                 socket.connect(addr=self.broker_addr)
 
@@ -91,7 +91,7 @@ class Job(object):
 
                 return msgid
             else:
-                if self.async and not self.broker_addr:
+                if self.async_ and not self.broker_addr:
                     logger.warning('No EMQ_BROKER_ADDR defined. Running '
                                    'function `{}` synchronously'.format(
                                        f.__name__))
@@ -101,13 +101,13 @@ class Job(object):
         return f
 
 
-def job(func, broker_addr=None, queue=None, async=True, *args,
+def job(func, broker_addr=None, queue=None, async_=True, *args,
         **kwargs):
     """
     Functional decorator helper for creating a deferred eventmq job. See
     :class:`Job` for more information.
     """
-    decorator = Job(queue=queue, broker_addr=broker_addr, async=async)
+    decorator = Job(queue=queue, broker_addr=broker_addr, async_=async_)
 
     if callable(func):
         return decorator(func)

--- a/eventmq/subscriber.py
+++ b/eventmq/subscriber.py
@@ -1,6 +1,7 @@
 """
 derp subscriber
 """
+from past.builtins import xrange
 import zmq
 
 
@@ -18,4 +19,4 @@ if __name__ == "__main__":
         # block until something comes in. normally you'd do something with
         # this in another thread or something
         for s in sockets:
-            print s.recv_multipart()  # noqa
+            print(s.recv_multipart())  # noqa

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     description='EventMQ job execution and messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=[
-        'pyzmq==15.4.0',
+        'pyzmq==18.1.0',
         'six==1.10.0',
         'monotonic==0.4',
         'croniter==0.3.10',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     scripts=[
         'bin/emq-cli',


### PR DESCRIPTION
# What?
- Updated `print`, `xrange` and `unicode` functions for python 2/3 compatibility.
- Replaced parameter named `async` to `async_` because `async` and `await` are now reserved keywords since python 3.7.
- Updated `pyzmq` lib to the latest version.

# Why?
Codebase should have the support of python 3.7.