### PR TITLE
Fix python 23 compatibility issues

### DIFF
--- a/bin/logwatcher.py
+++ b/bin/logwatcher.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import zmq
 
 s = zmq.Context.instance().socket(zmq.SUB)
-s.setsockopt(zmq.SUBSCRIBE, '')
+s.setsockopt(zmq.SUBSCRIBE, b'')
 s.connect('tcp://127.0.0.1:33445')
 
 poller = zmq.Poller()

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.11'
+__version__ = '0.3.12'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -18,7 +18,6 @@
 Ensures things about jobs and spawns the actual tasks
 """
 from json import dumps as serializer, loads as deserializer
-
 import logging
 from multiprocessing import Manager as MPManager
 import os
@@ -26,6 +25,7 @@ import signal
 import sys
 import time
 
+from six.moves import range
 import zmq
 
 from eventmq.log import setup_logger
@@ -142,7 +142,7 @@ class JobManager(HeartbeatMixin, EMQPService):
                 w.start()
                 self._workers[w.pid] = w
 
-        return self._workers.values()
+        return list(self._workers.values())
 
     def _start_event_loop(self):
         """
@@ -333,7 +333,7 @@ class JobManager(HeartbeatMixin, EMQPService):
         Worker died of natural causes, ensure its death and
         remove from tracking, will be replaced on next heartbeat
         """
-        if pid in self._workers.keys():
+        if pid in list(self._workers.keys()):
             del self._workers[pid]
 
     def worker_ready(self, reply, msgid, death, pid):

--- a/eventmq/pub.py
+++ b/eventmq/pub.py
@@ -20,7 +20,6 @@ Publishes messages to subscribers
 import logging
 
 from eventmq.log import setup_logger
-
 from . import conf, poller, publisher, receiver
 from .constants import STATUS
 from .utils.classes import HeartbeatMixin

--- a/eventmq/publisher.py
+++ b/eventmq/publisher.py
@@ -19,6 +19,7 @@ Publishes messages to subscribers
 """
 import logging
 
+import six
 import zmq
 
 from . import constants
@@ -36,7 +37,8 @@ class Publisher():
 
     def __init__(self, *args, **kwargs):
         self.zcontext = kwargs.get('context', zmq.Context.instance())
-        self.name = kwargs.get('name', generate_device_name())
+        self.name = six.ensure_binary(kwargs.get('name',
+                                                 generate_device_name()))
 
         self.zsocket = kwargs.get('socket', self.zcontext.socket(zmq.PUB))
         self.zsocket.setsockopt(zmq.IDENTITY, self.name)

--- a/eventmq/publisher.py
+++ b/eventmq/publisher.py
@@ -67,7 +67,8 @@ class Publisher():
 
     def publish(self, topic, msg):
         logger.debug("Notifying topic: {}".format(topic))
-        return self.zsocket.send_multipart([topic, msg])
+        return self.zsocket.send_multipart([six.ensure_binary(topic),
+                                            six.ensure_binary(msg)])
 
     @property
     def ready(self):

--- a/eventmq/receiver.py
+++ b/eventmq/receiver.py
@@ -19,6 +19,7 @@ The receiver is responsible for receiveing messages
 """
 import logging
 
+import six
 import zmq
 
 from . import conf, constants
@@ -59,7 +60,8 @@ class Receiver(ZMQReceiveMixin, ZMQSendMixin):
         self.zcontext = kwargs.get('context', zmq.Context.instance())
         self.zcontext.set(zmq.MAX_SOCKETS, conf.MAX_SOCKETS)
 
-        self.name = kwargs.get('name', generate_device_name())
+        self.name = six.ensure_binary(kwargs.get('name',
+                                                 generate_device_name()))
 
         self.zsocket = kwargs.get('socket', self.zcontext.socket(zmq.ROUTER))
         self.zsocket.setsockopt(zmq.IDENTITY, self.name)

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -17,6 +17,8 @@
 =============================
 Handles cron and other scheduled tasks
 """
+from __future__ import print_function
+
 from hashlib import sha1 as emq_hash
 import importlib
 import json
@@ -29,7 +31,6 @@ from croniter import croniter
 from six import iteritems, next
 
 from eventmq.log import setup_logger
-
 from . import __version__
 from . import conf, constants
 from .client.messages import send_request

--- a/eventmq/subscriber.py
+++ b/eventmq/subscriber.py
@@ -1,7 +1,10 @@
 """
 derp subscriber
 """
+from __future__ import print_function
+
 from past.builtins import xrange
+import six
 import zmq
 
 
@@ -11,7 +14,7 @@ if __name__ == "__main__":
         ctx = zmq.Context()
         s = ctx.socket(zmq.SUB)
         s.linger = 0
-        s.setsockopt(zmq.SUBSCRIBE, str(i))
+        s.setsockopt(zmq.SUBSCRIBE, six.ensure_binary(str(i)))
         s.connect('tcp://127.0.0.1:47299')
         sockets.append(s)
 

--- a/eventmq/switch.py
+++ b/eventmq/switch.py
@@ -5,5 +5,5 @@ if __name__ == "__main__":
     # switch.listen('tcp://127.0.0.1:47331', 'tcp://127.0.0.1:47330')
     try:
         switch.start()
-    except:
+    except Exception:
         switch.stop()

--- a/eventmq/tests/test_router.py
+++ b/eventmq/tests/test_router.py
@@ -18,6 +18,7 @@ import unittest
 
 from freezegun import freeze_time
 import mock
+from six.moves import range
 from testfixtures import LogCapture
 import zmq
 
@@ -318,7 +319,7 @@ class TestCase(unittest.TestCase):
 
         # There should be no keys because the code checks for their existence
         # to know if there is a waiting message
-        self.assertEqual(0, len(self.router.waiting_messages.keys()))
+        self.assertEqual(0, len(list(self.router.waiting_messages.keys())))
 
         # No waiting messages
         self.router.on_ready(worker1_id, ready_msgid1, ['READY', ready_msgid1])

--- a/eventmq/tests/test_utils.py
+++ b/eventmq/tests/test_utils.py
@@ -30,6 +30,7 @@ import sys
 import unittest
 
 import mock
+from six.moves import range
 
 from .. import conf
 from .. import constants

--- a/eventmq/tests/utils.py
+++ b/eventmq/tests/utils.py
@@ -14,6 +14,7 @@
 # along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
 import uuid
 
+import six
 import zmq
 
 from .. import conf, constants
@@ -48,12 +49,12 @@ def send_raw_INFORM(sock, type_, queues=(conf.DEFAULT_QUEUE_NAME,)):
     """
     msgid = str(uuid.uuid4())
     tracker = sock.zsocket.send_multipart((
-        '',
-        constants.PROTOCOL_VERSION,
-        'INFORM',
-        msgid,
-        ','.join(queues),
-        type_
+        b'',
+        six.ensure_binary(constants.PROTOCOL_VERSION),
+        b'INFORM',
+        six.ensure_binary(msgid),
+        six.ensure_binary(','.join(queues)),
+        six.ensure_binary(type_)
     ), copy=False, track=True)
     tracker.wait(1)
 
@@ -72,10 +73,10 @@ def send_raw_READY(sock):
     """
     msgid = str(uuid.uuid4())
     tracker = sock.zsocket.send_multipart((
-        '',
-        constants.PROTOCOL_VERSION,
-        'READY',
-        msgid
+        b'',
+        six.ensure_binary(constants.PROTOCOL_VERSION),
+        b'READY',
+        six.ensure_binary(msgid)
     ), copy=False, track=True)
     tracker.wait(1)
 

--- a/eventmq/utils/__init__.py
+++ b/eventmq/utils/__init__.py
@@ -27,6 +27,7 @@ like creating message more simple.
    settings
    timeutils
 """
+from six.moves import map
 
 
 def random_characters():

--- a/eventmq/utils/classes.py
+++ b/eventmq/utils/classes.py
@@ -422,7 +422,7 @@ class ZMQSendMixin(object):
             self.zsocket.send_multipart(msg,
                                         flags=zmq.NOBLOCK)
         except zmq.error.ZMQError as e:
-            if 'No route' in e.message:
+            if 'No route' in str(e):
                 raise exceptions.PeerGoneAwayError(e)
 
     def send(self, message, protocol_version):
@@ -469,7 +469,7 @@ class EMQdeque(object):
         return "{}".format(str(self._queue))
 
     def __unicode__(self):
-        return "{}".format(six.u(self._queue))
+        return "{}".format(six.text_type(self._queue))
 
     def __repr__(self):
         return "{}".format(repr(self._queue))
@@ -519,7 +519,7 @@ class EMQdeque(object):
             bool: True if the deque contains at least ``full`` items. False
             otherwise
         """
-        if self.full and self.full is not 0:
+        if self.full and self.full != 0:
             return len(self._queue) >= self.full
         else:
             return False
@@ -541,7 +541,7 @@ class EMQdeque(object):
             bool: True if the deque contains at least ``pfull`` items.
             False otherwise
         """
-        if self.pfull and self.pfull is not 0:
+        if self.pfull and self.pfull != 0:
             return len(self._queue) >= self.pfull
         else:
             return False

--- a/eventmq/utils/classes.py
+++ b/eventmq/utils/classes.py
@@ -411,6 +411,10 @@ class ZMQSendMixin(object):
 
         msg = encodify(headers + message)
 
+        # Decode bytes to strings in python3
+        if sys.version[0] == '3' and type(msg[0] in (bytes,)):
+            msg = [m.decode() for m in msg]
+
         # If it's not at least 4 frames long then most likely it isn't an
         # eventmq message
         if len(msg) > 4 and \
@@ -419,7 +423,7 @@ class ZMQSendMixin(object):
             logger.debug('Sending message: %s' % str(msg))
 
         try:
-            self.zsocket.send_multipart(msg,
+            self.zsocket.send_multipart([six.ensure_binary(m) for m in msg],
                                         flags=zmq.NOBLOCK)
         except zmq.error.ZMQError as e:
             if 'No route' in str(e):

--- a/eventmq/utils/encoding.py
+++ b/eventmq/utils/encoding.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
 from past.builtins import basestring
+from six.moves import range
 
 from .. import conf
 

--- a/eventmq/utils/functions.py
+++ b/eventmq/utils/functions.py
@@ -4,6 +4,8 @@ import inspect
 import json
 import sys
 
+import six
+
 from .. import log
 from ..exceptions import CallableFromPathError
 
@@ -70,7 +72,7 @@ def arguments_hash(*args, **kwargs):
     }
 
     data = json.dumps(args, cls=IgnoreJSONEncoder)
-    return hashlib.sha1(data).hexdigest()
+    return hashlib.sha1(six.ensure_binary(data)).hexdigest()
 
 
 def name_from_callable(func):

--- a/eventmq/utils/messages.py
+++ b/eventmq/utils/messages.py
@@ -18,6 +18,8 @@
 """
 import logging
 
+import six
+
 from . import random_characters
 from .. import conf, constants, exceptions
 
@@ -153,7 +155,7 @@ def fwd_emqp_router_message(socket, recipient_id, payload):
     Args:
         socket: socket to send the message with
         recipient_id (str): the id of the connected device to reply to
-        payload (tuple): The message to send. The first frame should be an
+        payload (list): The message to send. The first frame should be an
             empty string
     """
     import zmq
@@ -166,7 +168,7 @@ def fwd_emqp_router_message(socket, recipient_id, payload):
     if conf.SUPER_DEBUG:
         logger.debug('Forwarding message: {}'.format(str(payload)))
     try:
-        socket.zsocket.send_multipart(payload,
+        socket.zsocket.send_multipart([six.ensure_binary(x) for x in payload],
                                       flags=zmq.NOBLOCK)
     except zmq.error.ZMQError as e:
         if e.errno in errnos:

--- a/eventmq/utils/messages.py
+++ b/eventmq/utils/messages.py
@@ -170,8 +170,8 @@ def fwd_emqp_router_message(socket, recipient_id, payload):
                                       flags=zmq.NOBLOCK)
     except zmq.error.ZMQError as e:
         if e.errno in errnos:
-            e.message = e.message + " {}".format(recipient_id)
-            raise exceptions.PeerGoneAwayError(e)
+            e_message = str(e) + " {}".format(recipient_id)
+            raise exceptions.PeerGoneAwayError(e_message)
         else:
             raise exceptions.EventMQError("errno {}: {}".format(e.errno,
                                                                 str(e)))

--- a/eventmq/utils/settings.py
+++ b/eventmq/utils/settings.py
@@ -28,6 +28,8 @@ import json
 import logging
 import os
 
+from six.moves import map
+
 from . import tuplify
 from .. import conf
 

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -93,7 +93,7 @@ class MultiprocessWorker(Process):
                 if os.getppid() != self.ppid:
                     break
                 continue
-            except Exception as e:
+            except Exception:
                 break
             finally:
                 # If I'm an orphan, die

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pyzmq==18.1.0',
-        'six==1.10.0',
+        'six==1.14.0',
         'monotonic==0.4',
         'croniter==0.3.10',
         'future==0.15.2',
@@ -29,9 +29,9 @@ setup(
     extras_require={
           'docs': ['Sphinx==1.5.2', ],
           'testing': [
-              'flake8==3.2.1',
-              'flake8-import-order==0.11',
-              'flake8-print==2.0.2',
+              'flake8==3.7.8',
+              'flake8-import-order==0.18.1',
+              'flake8-print==3.1.0',
               'coverage==4.0.3',
               'testfixtures==4.7.0',
               'freezegun==0.3.7',


### PR DESCRIPTION
- version bump 0.3.12
- upgrade `six, flake8` libs
- fix `flake8` check issues
- add import of `from __future__ import print_function`
- fix params for `zsocket.setsockopt()`, `zsocket.send_multipart()` and `hashlib.sha1()` methods
- use `range, map` functions from `six`
- wrap result of `map, dict.keys(), dict.values()` functions in a list
- fix `EMQdeque.__unicode__()` method for py2 support
- fix using of exception messages
- update integer division for support the same behavior in py3 as is in py2
- refactor using of `filter` function