### PR TITLE
Change six requirement to >=1.14.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pyzmq==18.1.0',
-        'six==1.14.0',
+        'six>=1.14,<2',
         'monotonic==0.4',
         'croniter==0.3.10',
         'future==0.15.2',


### PR DESCRIPTION
What?
=====
I changed six==1.14.0 to six>=1.14<2

Why?
=====
Six 1.15.0 is out now, and we're getting version conflicts because pip
is installing 1.15.0 for other stuff but requiring 1.14.0 for eventmq.

I already fixed our environment by pinning to 1.14.0, but it seems like this is 
a good change in general to increase compatibility.